### PR TITLE
Add initializer

### DIFF
--- a/Source/GoldenRetriever.swift
+++ b/Source/GoldenRetriever.swift
@@ -2,6 +2,8 @@ import Foundation
 
 public struct GoldenRetriever {
 
+  public init() {}
+
   public func fetch(resource: String, closure: (data: NSData, error: NSError?) -> Void) {
     if let url = NSURL(string: resource) {
       let session = NSURLSession.sharedSession()


### PR DESCRIPTION
Now it's impossible to create `GoldenReceiver` when use it as a pod, because it has no accessible initialisers. This should fix it.
