### PR TITLE
Fix: handle nil response

### DIFF
--- a/Source/GoldenRetriever.swift
+++ b/Source/GoldenRetriever.swift
@@ -18,7 +18,7 @@ public class GoldenRetriever {
     })
   }
 
-  public func fetch(resource: String, closure: (data: NSData, response: NSURLResponse, error: NSError?) -> Void) {
+  public func fetch(resource: String, closure: (data: NSData, response: NSURLResponse?, error: NSError?) -> Void) {
     if let url = NSURL(string: resource) {
       let session = NSURLSession.sharedSession()
       let request = NSMutableURLRequest(URL: url)


### PR DESCRIPTION
GoldenRetriever used to crash when the network response was nil, e.g. when there were no Internet connection available, which is quite common on mobile devices.
I've added ? to make NSURLResponse optional, as in NSURLSession, so the receiver will have the possibility to handle nil-response.
@zenangst, please, check this. Simple, but important.
